### PR TITLE
Connection to PHP from Vite (npm run dev), Add/Edit Food Item Successful

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE=/api

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE=/IYO_Smart_Pantry/api

--- a/api/categories_list.php
+++ b/api/categories_list.php
@@ -1,0 +1,10 @@
+<?php
+// api/categories_list.php
+require __DIR__ . '/config.php';
+
+$sql = "SELECT categoryID AS id, categoryName AS name FROM categories ORDER BY name";
+$res = $mysqli->query($sql);
+$data = [];
+while ($row = $res->fetch_assoc()) $data[] = $row;
+
+send_json(['ok'=>true, 'data'=>$data]);

--- a/api/config.php
+++ b/api/config.php
@@ -1,51 +1,54 @@
 <?php
-// api/config.php
-
-// 1) Session（OTP 需要）
+// Session (if you need cookies)
 session_name('IYOSESSID');
 session_start();
 
-header('Content-Type: application/json; charset=utf-8');
-
-// 3) 可选 CORS（同源不需要；如果用 Vite 5173 开发服才打开下两行）
-// header('Access-Control-Allow-Origin: http://localhost:5173');
-// header('Access-Control-Allow-Credentials: true');
-if ($_SERVER['REQUEST_METHOD']==='OPTIONS'){ exit; }
-
-// 4) PDO 连接
-$dsn  = 'mysql:host=localhost;dbname=iyo_smart_pantry;charset=utf8mb4';
-$user = 'root';
-$pass = '';
-
-$options = [
-  PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-  PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-  // 可选：禁用模拟预处理，防止某些 edge case
-  // PDO::ATTR_EMULATE_PREPARES   => false,
-];
-
-try {
-  $pdo = new PDO($dsn, $user, $pass, $options);
-} catch (PDOException $e) {
-  http_response_code(500);
-  header('Content-Type: application/json; charset=utf-8');
-  echo json_encode(['ok'=>false,'error'=>'DB connect failed']);
+// CORS: enable when calling from Vite (http://localhost:5173)
+if (isset($_SERVER['HTTP_ORIGIN'])) {
+  if (preg_match('~^https?://localhost(:5173)?$~', $_SERVER['HTTP_ORIGIN'])) {
+    header('Access-Control-Allow-Origin: ' . $_SERVER['HTTP_ORIGIN']);
+    header('Access-Control-Allow-Credentials: true');
+    header('Vary: Origin');
+  }
+}
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+  header('Access-Control-Allow-Methods: GET,POST,PUT,PATCH,DELETE,OPTIONS');
+  header('Access-Control-Allow-Headers: Content-Type, X-Requested-With');
   exit;
 }
 
-// 5) 小工具
-function json_input() {
+// ---- DB (mysqli to match your other files) ----
+$DB_HOST = '127.0.0.1';
+$DB_USER = 'root';
+$DB_PASS = '';
+$DB_NAME = 'iyo_smart_pantry';
+
+$mysqli = @new mysqli($DB_HOST, $DB_USER, $DB_PASS, $DB_NAME);
+if ($mysqli->connect_errno) {
+  http_response_code(500);
+  header('Content-Type: application/json; charset=utf-8');
+  echo json_encode(['ok'=>false, 'error'=>'DB connect failed', 'detail'=>$mysqli->connect_error]);
+  exit;
+}
+$mysqli->set_charset('utf8mb4');
+
+// ---- Helpers (both names for compatibility) ----
+function read_json() {
   $raw = file_get_contents('php://input');
   $d = json_decode($raw, true);
   if (is_array($d)) return $d;
   if (!empty($_POST)) return $_POST;
-  if ($_SERVER['REQUEST_METHOD'] === 'GET' && !empty($_GET)) return $_GET;
+  if (!empty($_GET))  return $_GET;
   return [];
 }
 
-function respond($arr, $code=200){
+function send_json($arr, $code = 200) {
   http_response_code($code);
   header('Content-Type: application/json; charset=utf-8');
   echo json_encode($arr);
   exit;
 }
+
+// Aliases so older/newer files work the same
+function json_input() { return read_json(); }
+function respond($arr, $code = 200) { return send_json($arr, $code); }

--- a/api/food_add.php
+++ b/api/food_add.php
@@ -1,0 +1,52 @@
+<?php
+// C:\xampp\htdocs\IYO_Smart_Pantry\api\food_add.php
+require __DIR__.'/config.php';
+$d = read_json();
+
+$need = ['foodName','quantity','expiryDate','userID','categoryID','unitID'];
+foreach ($need as $k) {
+  if (!isset($d[$k]) || $d[$k] === '') {
+    send_json(['ok'=>false,'error'=>"Missing $k"], 400);
+  }
+}
+
+$is_expiryStatus = (strtotime($d['expiryDate']) < strtotime('today')) ? 1 : 0;
+$is_plan = !empty($d['is_plan']) ? 1 : 0;
+
+$sql = "INSERT INTO foods
+  (foodName, quantity, expiryDate, is_expiryStatus, is_plan, storageLocation, remark, userID, categoryID, unitID)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+$stmt = $mysqli->prepare($sql);
+if (!$stmt) send_json(['ok'=>false,'error'=>$mysqli->error], 500);
+
+$storage = $d['storageLocation'] ?? '';
+$remark  = $d['remark'] ?? '';
+
+$stmt->bind_param(
+  'sdsiisssss',
+  $d['foodName'],
+  $d['quantity'],
+  $d['expiryDate'],
+  $is_expiryStatus,
+  $is_plan,
+  $storage,
+  $remark,
+  $d['userID'],
+  $d['categoryID'],
+  $d['unitID']
+);
+
+if (!$stmt->execute()) {
+  send_json(['ok'=>false,'error'=>$stmt->error], 500);
+}
+
+// PK is varchar with trigger; fetch latest for that user
+$q = $mysqli->prepare("SELECT foodID FROM foods WHERE userID=? ORDER BY CAST(SUBSTRING(foodID,2) AS UNSIGNED) DESC LIMIT 1");
+$q->bind_param('s', $d['userID']);
+$q->execute();
+$foodID = null;
+$q->bind_result($foodID);
+$q->fetch();
+$q->close();
+
+send_json(['ok'=>true, 'foodID'=>$foodID]);

--- a/api/food_delete.php
+++ b/api/food_delete.php
@@ -1,0 +1,10 @@
+<?php
+require __DIR__.'/config.php';
+$d = read_json();
+if (empty($d['foodID'])) send_json(['ok'=>false,'error'=>'Missing foodID'], 400);
+
+$stmt = $mysqli->prepare("DELETE FROM foods WHERE foodID=?");
+$stmt->bind_param('s', $d['foodID']);
+$ok = $stmt->execute();
+if (!$ok) send_json(['ok'=>false,'error'=>$stmt->error], 500);
+send_json(['ok'=>true, 'affected'=>$stmt->affected_rows]);

--- a/api/food_update.php
+++ b/api/food_update.php
@@ -1,0 +1,45 @@
+<?php
+// C:\xampp\htdocs\IYO_Smart_Pantry\api\food_update.php
+require __DIR__.'/config.php';
+$d = read_json();
+
+$need = ['foodID','foodName','quantity','expiryDate','userID','categoryID','unitID'];
+foreach ($need as $k) {
+  if (!isset($d[$k]) || $d[$k] === '') {
+    send_json(['ok'=>false,'error'=>"Missing $k"], 400);
+  }
+}
+
+$is_expiryStatus = (strtotime($d['expiryDate']) < strtotime('today')) ? 1 : 0;
+$is_plan = !empty($d['is_plan']) ? 1 : 0;
+
+$sql = "UPDATE foods
+        SET foodName=?, quantity=?, expiryDate=?, is_expiryStatus=?, is_plan=?,
+            storageLocation=?, remark=?, categoryID=?, unitID=?
+        WHERE foodID=? AND userID=?";
+$stmt = $mysqli->prepare($sql);
+if (!$stmt) send_json(['ok'=>false,'error'=>$mysqli->error], 500);
+
+$storage = $d['storageLocation'] ?? '';
+$remark  = $d['remark'] ?? '';
+
+$stmt->bind_param(
+  'sdsiissssss',
+  $d['foodName'],
+  $d['quantity'],
+  $d['expiryDate'],
+  $is_expiryStatus,
+  $is_plan,
+  $storage,
+  $remark,
+  $d['categoryID'],
+  $d['unitID'],
+  $d['foodID'],
+  $d['userID']
+);
+
+if (!$stmt->execute()) {
+  send_json(['ok'=>false,'error'=>$stmt->error], 500);
+}
+
+send_json(['ok'=>true]);

--- a/api/ping.php
+++ b/api/ping.php
@@ -1,0 +1,3 @@
+<?php
+require __DIR__ . '/config.php';
+send_json(['ok' => true, 'msg' => 'pong', 'time' => date('c')]);

--- a/api/units_list.php
+++ b/api/units_list.php
@@ -1,0 +1,10 @@
+<?php
+// api/units_list.php
+require __DIR__ . '/config.php';
+
+$sql = "SELECT unitID AS id, unitName AS name FROM units ORDER BY name";
+$res = $mysqli->query($sql);
+$data = [];
+while ($row = $res->fetch_assoc()) $data[] = $row;
+
+send_json(['ok'=>true, 'data'=>$data]);

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>IYO Smart Pantry</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/component/FoodFormModal.jsx
+++ b/src/component/FoodFormModal.jsx
@@ -1,34 +1,85 @@
-// src/components/FoodFormModal.jsx
-import { useEffect, useState } from "react";
+// C:\xampp\htdocs\IYO_Smart_Pantry\src\components\FoodFormModal.jsx
+import { useEffect, useRef, useState } from "react";
+import { apiGet, apiPost } from "../lib/api";
+
+const toStatus = (yyyyMmDd) =>
+  new Date(yyyyMmDd) < new Date() ? "Expired" : "Available";
 
 export default function FoodFormModal({
   open,
-  mode = "add",                 // 'add' | 'edit'
-  initial = {},                 // { id?, name, qty, unit, category, expiry, location, remark }
+  mode = "add",
+  initial = {},
+  userId = "U2",
   onClose,
-  onSave,                       // (data) => void
+  onSave,
 }) {
   const [f, setF] = useState({
     name: "",
     qty: 1,
-    unit: "ps",
-    category: "Grains",
+    categoryID: "",
+    unitID: "",
     expiry: "",
     location: "",
     remark: "",
   });
 
+  const [catOpts, setCatOpts] = useState([]);
+  const [unitOpts, setUnitOpts] = useState([]);
+  const [loadingOpts, setLoadingOpts] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState("");
+
+  const fetchedRef = useRef(false);
+
   useEffect(() => {
-    if (!open) return;
-    setF({
-      name: initial.name ?? "",
-      qty: initial.qty ?? 1,
-      unit: initial.unit ?? "ps",
-      category: initial.category ?? "Grains",
-      expiry: initial.expiry ?? "",
-      location: initial.location ?? "",
-      remark: initial.remark ?? "",
-    });
+    if (!open) { fetchedRef.current = false; return; }
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
+
+    let cancelled = false;
+    setLoadingOpts(true);
+    setErr("");
+
+    (async () => {
+      try {
+        const [cats, units] = await Promise.all([
+          apiGet("/categories_list.php"),
+          apiGet("/units_list.php"),
+        ]);
+
+        if (cancelled) return;
+        const c = cats.data || [];
+        const u = units.data || [];
+        setCatOpts(c);
+        setUnitOpts(u);
+
+        const pickCatID =
+          initial.categoryID ||
+          c.find((x) => x.name === initial.category)?.id ||
+          c[0]?.id || "";
+
+        const pickUnitID =
+          initial.unitID ||
+          u.find((x) => x.name === initial.unit)?.id ||
+          u[0]?.id || "";
+
+        setF({
+          name: initial.name ?? "",
+          qty: Number(initial.qty ?? 1),
+          categoryID: pickCatID,
+          unitID: pickUnitID,
+          expiry: (initial.expiry ?? "").slice(0, 10),
+          location: initial.location ?? "",
+          remark: initial.remark ?? "",
+        });
+      } catch (e) {
+        if (!cancelled) setErr("Failed to load options");
+      } finally {
+        if (!cancelled) setLoadingOpts(false);
+      }
+    })();
+
+    return () => { cancelled = true; };
   }, [open, initial]);
 
   useEffect(() => {
@@ -39,8 +90,78 @@ export default function FoodFormModal({
 
   if (!open) return null;
 
-  const canSave = f.name.trim() && f.expiry;
-  const step = (d) => setF((s) => ({ ...s, qty: Math.max(1, s.qty + d) }));
+  const canSave = f.name.trim() && f.expiry && f.categoryID && f.unitID && Number(f.qty) > 0;
+  const step = (d) => setF((s) => ({ ...s, qty: Math.max(1, Number(s.qty) + d) }));
+
+  const catName = catOpts.find((c) => c.id === f.categoryID)?.name || "";
+  const unitName = unitOpts.find((u) => u.id === f.unitID)?.name || "";
+
+  async function submit() {
+    if (!canSave || saving) return;
+    setSaving(true);
+    setErr("");
+
+    const payload = {
+      foodName: f.name.trim(),
+      quantity: Number(f.qty),
+      expiryDate: f.expiry,
+      is_plan: 0,
+      storageLocation: f.location || "",
+      remark: f.remark || "",
+      userID: userId,
+      categoryID: f.categoryID,
+      unitID: f.unitID,
+    };
+
+    try {
+      if (mode === "add") {
+        const res = await apiPost("/food_add.php", payload);
+        const foodID = res.foodID || null;
+
+        onSave?.({
+          id: foodID,
+          foodID,
+          name: f.name,
+          category: catName,
+          qty: f.qty,
+          unit: unitName,
+          expiry: f.expiry,
+          status: toStatus(f.expiry),
+          location: f.location || "",
+          remark: f.remark || "",
+          userID: userId,
+          categoryID: f.categoryID,
+          unitID: f.unitID,
+        });
+        onClose?.();
+      } else {
+        const foodID = initial.foodID || initial.id;
+        if (!foodID) throw new Error("Missing foodID for edit");
+        await apiPost("/food_update.php", { foodID, ...payload });
+
+        onSave?.({
+          id: foodID,
+          foodID,
+          name: f.name,
+          category: catName,
+          qty: f.qty,
+          unit: unitName,
+          expiry: f.expiry,
+          status: toStatus(f.expiry),
+          location: f.location || "",
+          remark: f.remark || "",
+          userID: userId,
+          categoryID: f.categoryID,
+          unitID: f.unitID,
+        });
+        onClose?.();
+      }
+    } catch (e) {
+      setErr(e.message || "Network error");
+    } finally {
+      setSaving(false);
+    }
+  }
 
   return (
     <div className="modal" onClick={onClose}>
@@ -48,20 +169,34 @@ export default function FoodFormModal({
         <button className="close" onClick={onClose}>✕</button>
         <h3 className="modal-title">{mode === "edit" ? "Edit" : "Add Food"}</h3>
 
+        {err && (
+          <div className="mb-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {err}
+          </div>
+        )}
+
         <div className="form-grid">
           <div className="form-row">
             <label>Item name</label>
-            <input className="input" placeholder="Eg. (Egg)" value={f.name}
-                   onChange={(e) => setF({ ...f, name: e.target.value })} />
+            <input
+              className="input"
+              placeholder="Eg. (Egg)"
+              value={f.name}
+              onChange={(e) => setF({ ...f, name: e.target.value })}
+            />
           </div>
 
           <div className="form-row">
             <label>Category</label>
-            <select className="input" value={f.category}
-                    onChange={(e) => setF({ ...f, category: e.target.value })}>
-              <option>Grains</option><option>Protein</option>
-              <option>Vegetables</option><option>Fruits</option>
-              <option>Dairy</option><option>Other</option>
+            <select
+              className="input"
+              disabled={loadingOpts}
+              value={f.categoryID}
+              onChange={(e) => setF({ ...f, categoryID: e.target.value })}
+            >
+              {catOpts.map((c) => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
             </select>
           </div>
 
@@ -71,40 +206,54 @@ export default function FoodFormModal({
               <button className="step" onClick={() => step(-1)}>-</button>
               <span className="qty-num">{f.qty}</span>
               <button className="step" onClick={() => step(1)}>+</button>
-              <select className="input unit" value={f.unit}
-                      onChange={(e) => setF({ ...f, unit: e.target.value })}>
-                <option value="ps">ps</option>
-                <option value="kg">kg</option>
-                <option value="g">g</option>
-                <option value="L">L</option>
-                <option value="ml">ml</option>
+              <select
+                className="input unit"
+                disabled={loadingOpts}
+                value={f.unitID}
+                onChange={(e) => setF({ ...f, unitID: e.target.value })}
+              >
+                {unitOpts.map((u) => (
+                  <option key={u.id} value={u.id}>{u.name}</option>
+                ))}
               </select>
             </div>
           </div>
 
           <div className="form-row">
             <label>Expiry date</label>
-            <input type="date" className="input" value={f.expiry}
-                   onChange={(e) => setF({ ...f, expiry: e.target.value })} />
+            <input
+              type="date"
+              className="input"
+              value={f.expiry}
+              onChange={(e) => setF({ ...f, expiry: e.target.value })}
+            />
           </div>
 
           <div className="form-row">
             <label>Storage Location</label>
-            <input className="input" placeholder="Optional" value={f.location}
-                   onChange={(e) => setF({ ...f, location: e.target.value })} />
+            <input
+              className="input"
+              placeholder="Optional"
+              value={f.location}
+              onChange={(e) => setF({ ...f, location: e.target.value })}
+            />
           </div>
 
           <div className="form-row">
             <label>Remark</label>
-            <input className="input" placeholder="Optional" value={f.remark}
-                   onChange={(e) => setF({ ...f, remark: e.target.value })} />
+            <input
+              className="input"
+              placeholder="Optional"
+              value={f.remark}
+              onChange={(e) => setF({ ...f, remark: e.target.value })}
+            />
           </div>
         </div>
 
         <div className="modal-actions">
-          <button className="btn secondary" onClick={onClose}>Cancel</button>
-          <button className="btn primary" disabled={!canSave} onClick={() => onSave?.(f)}>
-            {mode === "edit" ? "Save" : "Add"}
+          <button className="btn secondary" onClick={onClose} disabled={saving}>Cancel</button>
+          <button className="btn primary" disabled={!canSave || saving} onClick={submit}>
+            {saving ? "Saving..." : mode === "edit" ? "Save" : "Add"}
           </button>
         </div>
       </div>

--- a/src/component/header.jsx
+++ b/src/component/header.jsx
@@ -50,3 +50,29 @@ function IconButton({ children, title }) {
     </button>
   );
 }
+
+/*import { apiGet } from '../lib/api'
+import { useState } from 'react'
+
+export default function Header() {
+  const [pong, setPong] = useState('')
+
+  async function testPing() {
+    try {
+      const j = await apiGet('/ping.php')
+      console.log('PING JSON:', j)        // <-- look in DevTools console
+      // show fallback text if keys are missing, so you can see it's the right file
+      setPong(`${j.msg ?? '(no msg)'} @ ${j.time ?? '(no time)'} | raw=${JSON.stringify(j)}`)
+    } catch (e) {
+      console.error(e)
+      setPong('FAILED: ' + e.message)
+    }
+  }
+
+  return (
+    <header style={{padding:12}}>
+      <button onClick={testPing}>Test API</button>
+      {pong && <span style={{marginLeft:12}}>{pong}</span>}
+    </header>
+  )
+}*/

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,0 +1,29 @@
+// C:\xampp\htdocs\IYO_Smart_Pantry\src\lib\api.js
+export const API = import.meta.env.VITE_API_BASE;
+
+export async function apiGet(path, init = {}) {
+  const res = await fetch(`${API}${path}`, { credentials: 'include', ...init });
+  const text = await res.text();
+  let json;
+  try { json = JSON.parse(text); } catch {
+    throw new Error(`Non-JSON response: ${text.slice(0,200)}`);
+  }
+  if (!res.ok || json?.ok === false) throw new Error(json?.error || `HTTP ${res.status}`);
+  return json;
+}
+
+export async function apiPost(path, data) {
+  const res = await fetch(`${API}${path}`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  const text = await res.text();
+  let json;
+  try { json = JSON.parse(text); } catch {
+    throw new Error(`Non-JSON response: ${text.slice(0,200)}`);
+  }
+  if (!res.ok || json?.ok === false) throw new Error(json?.error || `HTTP ${res.status}`);
+  return json;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,20 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
+// Vite runs at http://localhost:5173
+// Apache serves at   http://localhost/IYO_Smart_Pantry
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      // Any fetch("/api/xxx") from the front-end
+      // will go to http://localhost/IYO_Smart_Pantry/api/xxx
+      '/api': {
+        target: 'http://localhost',
+        changeOrigin: true,
+        secure: false,
+        rewrite: p => p.replace(/^\/api/, '/IYO_Smart_Pantry/api'),
+      },
+    },
+  },
 })


### PR DESCRIPTION
Added **.env.development** and **.env.production** environment variable files that Vite loads automatically (depend on how to run the app) 
Development: npm run dev
Production: npm run build

**vite.config.js** configure vite as setup so can call to api/* during development to reach XAMPP PHP

**api.js** as a helper to prevent repeat fetch on hard code URLs. ( required to import into each component or jsx page that need to use backend)

EXAMPLE: 
import { apiGet, apiPost } from '**../lib/api**';
const res = await apiPost("**/food_add.php**", payload);

**ping.php** is for testing the connection between XAMPP and Vite.

**unit_list.php, categories.php** fetch out the list in database and show in input option

**food_add.php, food_update.php, food_delete.php** use to add, delete and edit food item.

**config.php** is to store the setting like DB-name, DB-password, DB-user, DB-host  and some shared use function that required.